### PR TITLE
[#7] Export API as Postman collection when running on localhost

### DIFF
--- a/hokuto_flask/.gitignore
+++ b/hokuto_flask/.gitignore
@@ -15,3 +15,6 @@ __pycache__/
 
 # App packaged by Zappa and ready to be deployed on AWS
 *.zip
+
+# Postman collections generated on my machine every time the Flask dev server runs
+postman_*

--- a/hokuto_flask/hokuto_flask/blueprints/__init__.py
+++ b/hokuto_flask/hokuto_flask/blueprints/__init__.py
@@ -1,2 +1,2 @@
-from .api import api_blueprint as api
+from .api import api_blueprint as api, api as flaskRestPlusApi
 from .page import page_blueprint as page

--- a/hokuto_flask/hokuto_flask/blueprints/api/__init__.py
+++ b/hokuto_flask/hokuto_flask/blueprints/api/__init__.py
@@ -19,6 +19,3 @@ api.namespaces.pop()
 api.add_namespace(ns=characters, path="/characters")
 api.add_namespace(ns=voice_actors, path="/voice_actors")
 api.add_namespace(ns=fighting_styles, path="/fighting_styles")
-
-# How to export as Postman collection? It says it needs an application context.
-# api.as_postman()

--- a/hokuto_flask/wsgi.py
+++ b/hokuto_flask/wsgi.py
@@ -14,6 +14,10 @@ See Also:
     https://stackoverflow.com/a/25319752/3036129
     https://github.com/Miserlou/Zappa#running-the-initial-setup--settings
 """
-from hokuto_flask.app import create_app
+import os
+from hokuto_flask.app import create_app, export_api_as_postman_collection
 
 application = create_app()
+
+if os.environ.get("FLASK_ENV", None) == "development":
+    export_api_as_postman_collection(application)


### PR DESCRIPTION
With this commit, every time the FLASK_ENV environment variable
is set to "development", the Flask-RESTPlus Api instance object
is exported as Postman collection (json).