### PR TITLE
[#13] Configure lambda to access AWS resources in a AWS VPC

### DIFF
--- a/hokuto_flask/zappa_settings.json
+++ b/hokuto_flask/zappa_settings.json
@@ -12,11 +12,16 @@
         "exclude": ["*.env"],
         "keep_warm": false,
         "lambda_description": "This lambda is the WSGI app entry point",
-        "memory_size": 128,
+        "memory_size": 512,
         "profile_name": "zappa",
         "project_name": "hokuto-flask",
         "runtime": "python3.7",
         "s3_bucket": "zappa-sy1v5zm6y",
+        "timeout_seconds": 30,
+        "vpc_config": {
+            "SecurityGroupIds": ["sg-0b80e1ef8a6503a98"],
+            "SubnetIds": ["subnet-946a55ff", "subnet-9af892e7", "subnet-0273094f"]
+        },
         "xray_tracing": true
     }
 }


### PR DESCRIPTION
With this commit the lambda can access the AWS RDS instance
that belong to a VPC (Virtual Private Cloud), thus a AWS
resource that is not publicly accessible.

This AWS RDS instance runs the PostgreSQL production database.